### PR TITLE
Fix: ILM Advance issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ frozen_ds.yaml
 mapping.yaml
 http_ca.crt
 docker_test/.kurl
+.env-shell
+.env-cloud
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -440,12 +440,12 @@ With `docker_test` so integral to testing `es-pii-tool`, an effort was made to m
 the setup and teardown of the Docker containers automatic.
 
 ```
-$ pytest --docker_create true --docker_destroy true
+$ pytest --docker_create true --docker_destroy true --es_version 8.15.1
 ```
 
 If `--docker_create true` and/or `--docker_destroy true` are omitted, the tests
 will assume you already have a functional test environment and the environment
-variables are configured in `.env`.
+variables are configured in `.env`, and that the `.env` file has been `source`-ed.
 
 The output looks like this:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ keywords = [
     'index'
 ]
 dependencies = [
-    'es_client>=8.15.1',
-    'es_wait>=0.9.1',
+    'es_client>=8.17.1',
+    'es_wait>=0.9.4',
 ]
 
 [project.optional-dependencies]

--- a/src/es_pii_tool/__init__.py
+++ b/src/es_pii_tool/__init__.py
@@ -2,5 +2,5 @@
 
 from .base import PiiTool
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 __all__ = ['exceptions', 'PiiTool']

--- a/src/es_pii_tool/base.py
+++ b/src/es_pii_tool/base.py
@@ -53,7 +53,12 @@ class PiiTool:
             return True  # We're done already
         # Log task start
         task.begin()
-        hits = get_hits(self.client, job.config['pattern'], job.config['query'])
+        hits = 0
+        try:
+            hits = get_hits(self.client, job.config['pattern'], job.config['query'])
+        except Exception as err:
+            logger.critical('Unable to count query result hits: %s', err)
+            raise err
         msg = f'{hits} hit(s)'
         logger.debug(msg)
         task.add_log(msg)

--- a/src/es_pii_tool/helpers/elastic_api.py
+++ b/src/es_pii_tool/helpers/elastic_api.py
@@ -176,15 +176,15 @@ def do_search(
     :type query: dict
     :type size: int
     """
+    kwargs = {
+        'index': index_pattern,
+        'query': query,
+        'size': size,
+        'expand_wildcards': ['open', 'hidden'],
+    }
+    logger.debug('Search kwargs = %s', kwargs)
     try:
-        response = dict(
-            client.search(
-                index=index_pattern,
-                query=query,
-                size=size,
-                expand_wildcards=['open', 'hidden'],
-            )
-        )
+        response = dict(client.search(**kwargs))  # type: ignore
         logger.debug(response)
     except (ApiError, NotFoundError, TransportError, BadRequestError) as err:
         msg = f'Attempt to collect search results yielded an exception: {err}'
@@ -738,9 +738,6 @@ def restore_index(
         )
         logger.debug('Response = %s', response)
         logger.info('Checking if restoration completed...')
-        # restore_check = Restore(
-        #     client, pause=PAUSE_VALUE, timeout=TIMEOUT_VALUE, index_list=[replacement]
-        # )
         try:
             es_waiter(client, Restore, index_list=[replacement], **WAITKW)
         except BadClientResult as exc:
@@ -755,6 +752,14 @@ def restore_index(
         )
         logger.error(msg)
         raise BadClientResult(msg, err)
+    # verify index is green
+    logger.info('Ensuring restored index is in "green" health state...')
+    res = dict(client.cluster.health(index=replacement, filter_path='status'))
+    logger.debug('res = %s', res)
+    if res['status'] == 'red':
+        msg = f'Restored index {replacement} is not in a healthy state'
+        logger.error(msg)
+        raise ValueMismatch(msg, 'index health is "red"', 'green or yellow')
 
 
 def redact_from_index(client: 'Elasticsearch', index_name: str, config: t.Dict) -> None:

--- a/src/es_pii_tool/helpers/steps.py
+++ b/src/es_pii_tool/helpers/steps.py
@@ -402,7 +402,12 @@ def confirm_ilm_phase(task: 'Task', stepname, var: DotMap, **kwargs) -> None:
     # Wait for phase to be "new"
     waitkw = {'pause': PAUSE_VALUE, 'timeout': TIMEOUT_VALUE}
     try:
+        # Update in es_wait 0.9.2:
+        # - If you send phase='new', it will wait for the phase to be 'new' or higher
+        # - This is where a user was getting stuck. They were waiting for 'new' but
+        # - the phase was already 'frozen', so it was endlessly checking for 'new'.
         es_waiter(var.client, IlmPhase, name=var.mount_name, phase='new', **waitkw)
+        # Wait for step to be "complete"
         es_waiter(var.client, IlmStep, name=var.mount_name, **waitkw)
     except BadClientResult as exc:
         failed_step(task, stepname, exc)
@@ -419,22 +424,34 @@ def confirm_ilm_phase(task: 'Task', stepname, var: DotMap, **kwargs) -> None:
     currstep = {'phase': expl['phase'], 'action': expl['action'], 'name': expl['step']}
     nextstep = {'phase': var.phase, 'action': 'complete', 'name': 'complete'}
     if not task.job.dry_run:  # Don't actually move_to_step if dry_run
-        logger.debug('currstep: %s', currstep)
-        logger.debug('nextstep: %s', nextstep)
-        logger.debug('PHASE: %s', var.phase)
-        try:
-            api.ilm_move(var.client, var.mount_name, currstep, nextstep)
-        except BadClientResult as exc:
-            failed_step(task, stepname, exc)
-        try:
-            es_waiter(
-                var.client, IlmPhase, name=var.mount_name, phase=var.phase, **waitkw
+        # Since we are now testing for 'new' or higher, we may not need to advance
+        # ILM phases. If the current step is already where we expect to be, log
+        # confirmation and move on.
+        if currstep == nextstep:
+            msg = (
+                f'{stepname}: {var.mount_name} is confirmed to be in ILM phase '
+                f'{var.phase}'
             )
-            es_waiter(var.client, IlmStep, name=var.mount_name, **waitkw)
-        except BadClientResult as phase_err:
-            msg = f'Unable to wait for ILM step to complete: ERROR :{phase_err}'
-            logger.error(msg)
-            failed_step(task, stepname, phase_err)
+            logger.debug(msg)
+        else:
+            # If we are not yet in the expected target phase, then proceed with the
+            # ILM phase change.
+            logger.debug('Current ILM Phase: %s', currstep)
+            logger.debug('Target ILM Phase: %s', nextstep)
+            logger.debug('PHASE: %s', var.phase)
+            try:
+                api.ilm_move(var.client, var.mount_name, currstep, nextstep)
+            except BadClientResult as exc:
+                failed_step(task, stepname, exc)
+            try:
+                es_waiter(
+                    var.client, IlmPhase, name=var.mount_name, phase=var.phase, **waitkw
+                )
+                es_waiter(var.client, IlmStep, name=var.mount_name, **waitkw)
+            except BadClientResult as phase_err:
+                msg = f'Unable to wait for ILM step to complete: ERROR :{phase_err}'
+                logger.error(msg)
+                failed_step(task, stepname, phase_err)
     else:
         msg = (
             f'{stepname}: Dry-Run: {var.mount_name} not moved/confirmed to ILM '

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ TPREF = 'data_warm,data_hot,data_content'
 cli_params = {
     'docker_create': 'False',
     'docker_destroy': 'False',
-    'es_version': '8.15.1',
+    'es_version': '8.17.1',
 }
 
 
@@ -378,7 +378,7 @@ def skip_localhost() -> None:
     def _skip_localhost(skip_it: bool) -> None:
         if skip_it:
             host = environ.get('TEST_ES_SERVER')
-            file = environ.get('ES_CLIENT_FILE', None)  # Path to es_client YAML config
+            file = environ.get('ESCLIENT_FILE', None)  # Path to es_client YAML config
             repo = environ.get('TEST_ES_REPO')
             if repo == LOCALREPO and host == 'https://127.0.0.1:9200' and not file:
                 pytest.skip(

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -71,6 +71,9 @@ class TestDefault(TestBuiltin):
 
     builtin = 'searchable_test'
 
+    # These tests are disabled for now, as they are not likely to be needed unless
+    # something very odd and unexpected is found in the future.
+
     # def test_first_pass_pattern(self, first_pass, tierpattern):
     #     """Check that our first_pass search pattern is as expected"""
     #     actual = first_pass['first_pass']['pattern']
@@ -113,30 +116,35 @@ class TestDefault(TestBuiltin):
             assert False
         assert True
 
-    def test_first_pass_results(self, client, tracker):
-        """Evaluate the success of the first_pass job"""
-        doc = client.get(index=tracker, id='first_pass')
-        logger.debug('first_pass job results: %s', doc)
-        assert doc['_source']['completed']
-        assert not doc['_source']['errors']
+    # These confirmation tests are disabled. Should one of these validations fail,
+    # the redaction process would also fail, making these tests redundant. They
+    # were useful during development, but are not needed for regular testing.
+    # They are preserved in case something comes up.
 
-    def test_second_pass_results(self, client, tracker):
-        """Evaluate the success of the second_pass job"""
-        doc = client.get(index=tracker, id='second_pass')
-        logger.debug('second_pass job results: %s', doc)
-        assert doc['_source']['completed']
-        assert not doc['_source']['errors']
+    # def test_first_pass_results(self, client, tracker):
+    #     """Evaluate the success of the first_pass job"""
+    #     doc = client.get(index=tracker, id='first_pass')
+    #     logger.debug('first_pass job results: %s', doc)
+    #     assert doc['_source']['completed']
+    #     assert not doc['_source']['errors']
 
-    def test_third_pass_results(self, client, tracker):
-        """Evaluate the success of the third_pass job"""
-        doc = client.get(index=tracker, id='third_pass')
-        logger.debug('third_pass job results: %s', doc)
-        assert doc['_source']['completed']
-        assert not doc['_source']['errors']
+    # def test_second_pass_results(self, client, tracker):
+    #     """Evaluate the success of the second_pass job"""
+    #     doc = client.get(index=tracker, id='second_pass')
+    #     logger.debug('second_pass job results: %s', doc)
+    #     assert doc['_source']['completed']
+    #     assert not doc['_source']['errors']
 
-    def test_final_pass_results(self, client, tracker):
-        """Evaluate the success of the final_pass job"""
-        doc = client.get(index=tracker, id='final_pass')
-        logger.debug('final_pass job results: %s', doc)
-        assert doc['_source']['completed']
-        assert not doc['_source']['errors']
+    # def test_third_pass_results(self, client, tracker):
+    #     """Evaluate the success of the third_pass job"""
+    #     doc = client.get(index=tracker, id='third_pass')
+    #     logger.debug('third_pass job results: %s', doc)
+    #     assert doc['_source']['completed']
+    #     assert not doc['_source']['errors']
+
+    # def test_final_pass_results(self, client, tracker):
+    #     """Evaluate the success of the final_pass job"""
+    #     doc = client.get(index=tracker, id='final_pass')
+    #     logger.debug('final_pass job results: %s', doc)
+    #     assert doc['_source']['completed']
+    #     assert not doc['_source']['errors']


### PR DESCRIPTION
A fix to how ILM phases are both detected and advanced was needed. This is described alongside the code changes [here](https://github.com/elastic/pii-tool/commit/d6bde252070bbf93b64f9bd75324bd78cf5386d9).

Other changes include a bump to the newest `es_wait` module which addresses changes to the Elasticsearch Python client with regard to non-GA features (primarily the Tasks API), and verifying that restored indices are not in a red state before proceeding.

