### PR TITLE
Ensure the while loop ends when ILM reaches its target

### DIFF
--- a/src/es_pii_tool/__init__.py
+++ b/src/es_pii_tool/__init__.py
@@ -2,5 +2,5 @@
 
 from .base import PiiTool
 
-__version__ = '0.9.2'
+__version__ = '0.9.3'
 __all__ = ['exceptions', 'PiiTool']

--- a/src/es_pii_tool/helpers/steps.py
+++ b/src/es_pii_tool/helpers/steps.py
@@ -458,6 +458,9 @@ def confirm_ilm_phase(task: 'Task', stepname, var: DotMap, **kwargs) -> None:
                 f'{var.phase}'
             )
             logger.debug(msg)
+            # Set both while loop critera to values that will end the loop
+            success = True
+            attempts = 3
         else:
             # If we are not yet in the expected target phase, then proceed with the
             # ILM phase change.


### PR DESCRIPTION
This was omitted by a tired person at the end of a long day.

```diff
--- a/src/es_pii_tool/helpers/steps.py
+++ b/src/es_pii_tool/helpers/steps.py
@@ -458,6 +458,9 @@ def confirm_ilm_phase(task: 'Task', stepname, var: DotMap, **kwargs) -> None:
                 f'{var.phase}'
             )
             logger.debug(msg)
+            # Set both while loop critera to values that will end the loop
+            success = True
+            attempts = 3
         else:
             # If we are not yet in the expected target phase, then proceed with the
             # ILM phase change.
```